### PR TITLE
fixed broken button "Exit preferences"

### DIFF
--- a/feedly.css
+++ b/feedly.css
@@ -1849,7 +1849,7 @@ table.prefErrorLog td.filename, table.prefErrorLog td.login, table.prefErrorLog 
 
 #ttrssPrefs #header {
 	position: relative;
-	z-index: 1;
+	z-index: 3;
 	float: right;
 	padding: 12px 10px 0;
 }


### PR DESCRIPTION
"Exit preferences" is covered by #pref-tabs_tablist, this fix moves #header over #pref-tabs_tablist.
Tested under Firefox 23 and Chromium 28.
