### PR TITLE
Update support string to 16.1

### DIFF
--- a/feedly.css
+++ b/feedly.css
@@ -1,4 +1,4 @@
-/* supports-version:15.7 */
+/* supports-version:16.1 */
 
 @import url(feedly/claro-mod.min.css);
 


### PR DESCRIPTION
New year, new arbitrary version number in tt-rss. I don't see anything (obvious) broken. This should be a clean update.