### PR TITLE
tt-rss 17.1

### DIFF
--- a/feedly.css
+++ b/feedly.css
@@ -1,4 +1,4 @@
-/* supports-version:16.8 */
+/* supports-version:17.1 */
 
 @import url(feedly/claro-mod.min.css);
 

--- a/feedly.css
+++ b/feedly.css
@@ -784,19 +784,13 @@ a:hover {
 	display: none;
 }
 
-#feeds-holder #feedTree > .dijitTreeNode > .dijitTreeContainer > .dijitTreeNode:first-child > .dijitTreeRow {
-	margin: 0 0 7px;
-	padding: 13px 6px;
+#feeds-holder #feedTree > .dijitTreeContainer > .dijitTreeNode > .dijitTreeNodeContainer > .dijitTreeNode:first-child {
+	margin-bottom: 13px;
+	padding: 13px 0;
 	border-bottom: 1px solid #d4d4d4;
 }
-#feeds-holder #feedTree > .dijitTreeNode > .dijitTreeContainer > .dijitTreeNode:first-child {
-	margin-bottom: 26px;
-}
-#feeds-holder #feedTree > .dijitTreeNode > .dijitTreeContainer > .dijitTreeNode:first-child .counterNode + .dijitInline {
-	padding: 0 !important;
-}
-#feeds-holder #feedTree > .dijitTreeNode > .dijitTreeContainer > .dijitTreeNode:first-child .feedIcon {
-	margin: 0 6px 0 -2px;
+#feeds-holder #feedTree > .dijitTreeContainer > .dijitTreeNode > .dijitTreeNodeContainer .feedIcon {
+	margin: 0 6px 0 9px;
 }
 
 /* main */

--- a/feedly.css
+++ b/feedly.css
@@ -701,15 +701,12 @@ a:hover {
 }
 
 #feeds-holder .dijitTreeRow {
-	overflow: hidden;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	padding: 4px 6px;
-	max-width: 100%;
 	border: 0;
 	background: transparent;
 	color: #909090;
-	text-overflow: ellipsis;
 	transition: color .2s;
 }
 #feeds-holder .dijitTreeRowSelected {
@@ -791,6 +788,15 @@ a:hover {
 }
 #feeds-holder #feedTree > .dijitTreeContainer > .dijitTreeNode > .dijitTreeNodeContainer .feedIcon {
 	margin: 0 6px 0 9px;
+}
+
+body#ttrssMain #feedTree.dijitTree .dijitTreeContainer {
+	max-width : 100%;
+}
+
+body#ttrssMain #feedTree.dijitTree .dijitTreeRow {
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 /* main */


### PR DESCRIPTION
Some of the CSS selectors have changed. And the Special feeds now have their own container, so I updated the CSS for that.

I couldn't figure out how to change the large 30px margin on the left side of the feeds tree, where the collapse button used to be. Sidebar collapse functionality in tt-rss has been moved to a new plugin (`toggle_sidebar`), whose button appears in the main feed area, not in the feed tree area.