### PR TITLE
Update supported version

### DIFF
--- a/feedly.css
+++ b/feedly.css
@@ -1,4 +1,4 @@
-/* supports-version:16.8 */
+/* supports-version:17.1 */
 
 @import url(feedly/claro-mod.min.css);
 


### PR DESCRIPTION
tt-rss has bumped it's version to 17.1. Did at least some basic testing at the theme still seems fully functional. Bumped the supports-version string to 17.1