### PR TITLE
bump supported version so the theme works on fresh installations

### DIFF
--- a/feedly-night.css
+++ b/feedly-night.css
@@ -1,4 +1,4 @@
-/* supports-version:17.12 */
+/* supports-version:18.8 */
 
 @import url(feedly.css);
 

--- a/feedly.css
+++ b/feedly.css
@@ -1,4 +1,4 @@
-/* supports-version:17.12 */
+/* supports-version:18.8 */
 
 @import url(feedly/claro-mod.min.css);
 


### PR DESCRIPTION
Quoting [TTRSS Wiki](https://git.tt-rss.org/fox/tt-rss/wiki/Themes):

> Third party themes are automatically disabled if tt-rss version changes, in this case theme CSS file needs to be updated: replace previous version code in supports-version:X.Y with VERSION_STATIC (i.e. the version you see at the bottom of Preferences, excluding git commit information).